### PR TITLE
feat(core): add AuthProvider for Credentials.Custom

### DIFF
--- a/core/src/commonMain/kotlin/io/natskt/api/AuthPayload.kt
+++ b/core/src/commonMain/kotlin/io/natskt/api/AuthPayload.kt
@@ -1,0 +1,10 @@
+package io.natskt.api
+
+public data class AuthPayload(
+	val authToken: String? = null,
+	val user: String? = null,
+	val pass: String? = null,
+	val jwt: String? = null,
+	val signature: String? = null,
+	val nkeyPublic: String? = null,
+)

--- a/core/src/commonMain/kotlin/io/natskt/api/AuthProviderScope.kt
+++ b/core/src/commonMain/kotlin/io/natskt/api/AuthProviderScope.kt
@@ -1,0 +1,38 @@
+package io.natskt.api
+
+import io.natskt.internal.ServerOperation
+import io.natskt.nkeys.NKeySeed
+
+public object AuthProviderScope {
+	/**
+	 * Sign the nonce from  a [ServerOperation.InfoOp].
+	 *
+	 * [nkeySeed] must be in format like: `SUAAABYOCUOCGKRRHA7UMTKULNRGS4DXP2CYZE42UGUK7NV5YTF5FWIXJQ`
+	 *
+	 * @return the Base-64 representation of the signed nonce
+	 */
+	public fun signNonce(
+		nkeySeed: String,
+		infoOp: ServerOperation.InfoOp,
+	): String? = infoOp.nonce?.let { signWithNkey(nkeySeed, it) }
+
+	/**
+	 * [nkeySeed] must be in format like: `SUAAABYOCUOCGKRRHA7UMTKULNRGS4DXP2CYZE42UGUK7NV5YTF5FWIXJQ`
+	 *
+	 * @param nkeySeed a valid nkey seed value
+	 * @param payload a string of bytes to sign
+	 * @return the Base-64 representation of the signed bytes
+	 */
+	public fun signWithNkey(
+		nkeySeed: String,
+		payload: String,
+	): String = signWithNkey(NKeySeed.parse(nkeySeed), payload.encodeToByteArray())
+
+	/**
+	 * @return the Base-64 representation of the signed bytes
+	 */
+	public fun signWithNkey(
+		nkeySeed: NKeySeed,
+		payload: ByteArray,
+	): String = nkeySeed.signToBase64(payload)
+}

--- a/core/src/commonMain/kotlin/io/natskt/api/Credentials.kt
+++ b/core/src/commonMain/kotlin/io/natskt/api/Credentials.kt
@@ -1,28 +1,88 @@
 package io.natskt.api
 
+import io.natskt.internal.ServerOperation
+
 public sealed interface Credentials {
+	/**
+	 * Use a JWT for identification as a user and nkey to sign the server nonce.
+	 */
 	public data class Jwt(
 		val token: String,
 		val nkey: String,
 	) : Credentials
 
+	/**
+	 * Use an explicit username and password.
+	 */
 	public data class Password(
 		val username: String,
 		val password: String,
 	) : Credentials
 
+	/**
+	 * Use a JWT and nkey, read from a standard NATS creds file. You must read and supply the file content.
+	 *
+	 * Identical to [Credentials.Jwt] in function, but reads credentials in the format:
+	 * ```txt
+	 * -----BEGIN NATS USER JWT-----
+	 * ey...
+	 * ------END NATS USER JWT------
+	 *
+	 * ************************* IMPORTANT *************************
+	 * NKEY Seed printed below can be used to sign and prove identity.
+	 * NKEYs are sensitive and should be treated as secrets.
+	 *
+	 * -----BEGIN USER NKEY SEED-----
+	 * SU...
+	 * ------END USER NKEY SEED------
+	 *
+	 * *************************************************************
+	 * ```
+	 */
 	public data class File(
 		val content: String,
 	) : Credentials
 
+	/**
+	 * Use a standalone nkey (without JWT) to sign the server nonce
+	 */
 	public data class Nkey(
 		val key: String,
 	) : Credentials
 
+	public fun interface AuthProvider {
+		public operator fun AuthProviderScope.invoke(info: ServerOperation.InfoOp): AuthPayload
+
+		public fun withScope(
+			scope: AuthProviderScope,
+			info: ServerOperation.InfoOp,
+		): AuthPayload = with(this) { scope.invoke(info) }
+	}
+
+	/**
+	 * Use an [AuthProvider], which returns an [AuthPayload]. This allows full control over the authentication parameters sent to the server.
+	 *
+	 * Your [AuthProvider] will be called with a [AuthProviderScope] and [ServerOperation.InfoOp].
+	 *
+	 * ### Signature
+	 * If you require a signature to be set (such as for the server's standard NKey challenge/response), you must set this yourself.
+	 *
+	 * [AuthProviderScope] contains [AuthProviderScope.signNonce] and [AuthProviderScope.signWithNkey], which you can use to create a signature when required.
+	 *
+	 * ### Example
+	 *
+	 * ```
+	 * val provider: Credentials.AuthProvider = Credentials.AuthProvider { info ->
+	 * 	val mySecret = ""
+	 * 	AuthPayload(
+	 * 		jwt = "ey...",
+	 * 		nkeyPublic = "UB...",
+	 * 		signature = signNonce(mySecret, info) // <- This comes from AuthProviderScope
+	 * 	)
+	 * }
+	 * ```
+	 */
 	public data class Custom(
-		val jwt: Jwt? = null,
-		val password: Password? = null,
-		val file: File? = null,
-		val nkey: Nkey? = null,
+		val provider: AuthProvider,
 	) : Credentials
 }


### PR DESCRIPTION
`Credentials.Custom` is now simpler. By creating an `AuthProvider`, you will have full control over the username, password, token (v1), JWT, nkey and signature fields that are used on connect to the server.

This should grant the flexibility to work with auth-callout. 