### PR TITLE
Core cleanup

### DIFF
--- a/core/common/src/commonMain/kotlin/io/natskt/api/Subject.kt
+++ b/core/common/src/commonMain/kotlin/io/natskt/api/Subject.kt
@@ -3,9 +3,6 @@ package io.natskt.api
 import io.natskt.api.internal.InternalNatsApi
 import kotlin.jvm.JvmInline
 
-private val disallowedSubjectChars = Regex("[\\u0000 \\t\\r\\n]")
-private val wildcardChars = Regex("[*>]")
-
 public class InvalidSubjectException(
 	subject: String,
 	message: String? = null,
@@ -44,8 +41,41 @@ public fun Subject.Companion.fullyQualified(s: String): Subject {
 	return Subject(s)
 }
 
+/**
+ * Returns `true` if [s] is not a valid NATS subject.
+ *
+ * Mirrors the wire-level validation done by nats.go's `badSubject`:
+ * rejects whitespace (space, tab, CR, LF) and any subject that has
+ * empty tokens (leading dot, trailing dot, or consecutive dots).
+ *
+ * UTF-8 characters are permitted; the server enforces `utf8_only` separately.
+ */
 @InternalNatsApi
-public fun isInvalidSubject(s: String): Boolean = disallowedSubjectChars.containsMatchIn(s)
+public fun isInvalidSubject(s: String): Boolean {
+	if (s.isEmpty()) return true
+	var tokenStart = 0
+	for (i in s.indices) {
+		when (s[i]) {
+			' ', '\t', '\r', '\n' -> return true
+			'.' -> {
+				if (i == tokenStart) return true
+				tokenStart = i + 1
+			}
+		}
+	}
+	return tokenStart == s.length
+}
 
+/**
+ * Returns `true` if [s] is not a valid fully-qualified (wildcard-free) NATS subject.
+ *
+ * Same checks as [isInvalidSubject], plus rejects the `*` and `>` wildcard tokens.
+ */
 @InternalNatsApi
-public fun isInvalidFullyQualifiedSubject(s: String): Boolean = disallowedSubjectChars.containsMatchIn(s) || wildcardChars.containsMatchIn(s)
+public fun isInvalidFullyQualifiedSubject(s: String): Boolean {
+	if (isInvalidSubject(s)) return true
+	for (c in s) {
+		if (c == '*' || c == '>') return true
+	}
+	return false
+}

--- a/core/common/src/commonMain/kotlin/io/natskt/api/SubjectToken.kt
+++ b/core/common/src/commonMain/kotlin/io/natskt/api/SubjectToken.kt
@@ -3,8 +3,6 @@ package io.natskt.api
 import io.natskt.api.internal.InternalNatsApi
 import kotlin.jvm.JvmInline
 
-private val disallowedTokenChars = Regex("[\\u0000 .*>\\t\\r\\n]")
-
 @JvmInline
 public value class SubjectToken(
 	public val token: String,
@@ -20,5 +18,24 @@ public fun SubjectToken.Companion.from(s: String): SubjectToken {
 	return SubjectToken(s)
 }
 
+/**
+ * Returns `true` if [s] is not a valid token (single subject token, stream name,
+ * consumer name, or KV bucket name).
+ *
+ * Mirrors nats.go's `validateStreamName` / `validateConsumerName`: rejects
+ * `>`, `*`, `.`, ` ` (space), `/`, `\`, plus tab/CR/LF for safety.
+ *
+ * Empty strings are also invalid.
+ *
+ * UTF-8 characters are permitted; the server enforces `utf8_only` separately.
+ */
 @InternalNatsApi
-public fun isInvalidToken(s: String): Boolean = disallowedTokenChars.containsMatchIn(s)
+public fun isInvalidToken(s: String): Boolean {
+	if (s.isEmpty()) return true
+	for (c in s) {
+		when (c) {
+			' ', '\t', '\r', '\n', '.', '*', '>', '/', '\\' -> return true
+		}
+	}
+	return false
+}

--- a/core/common/src/commonMain/kotlin/io/natskt/api/Subscription.kt
+++ b/core/common/src/commonMain/kotlin/io/natskt/api/Subscription.kt
@@ -19,6 +19,18 @@ public interface Subscription : AutoCloseable {
 	public suspend fun unsubscribe()
 
 	/**
+	 * Auto-unsubscribe after [after] more messages have been delivered.
+	 *
+	 * Sends `UNSUB <sid> <after>` to the server, which delivers up to [after] more
+	 * messages on this subscription and then auto-unsubscribes server-side.
+	 * Once [after] messages have been received, the subscription's [messages]
+	 * flow completes and [isActive] flips to `false`.
+	 *
+	 * @throws IllegalArgumentException if [after] is not positive
+	 */
+	public suspend fun unsubscribe(after: Int)
+
+	/**
 	 * initiates [unsubscribe]
 	 */
 	abstract override fun close()

--- a/core/src/commonMain/kotlin/io/natskt/api/ConnectionState.kt
+++ b/core/src/commonMain/kotlin/io/natskt/api/ConnectionState.kt
@@ -18,6 +18,16 @@ public data class ConnectionState(
 	var lastPongAt: Long?,
 	var messagesIn: ULong,
 	var messagesOut: ULong,
+	/**
+	 * Reason text from the most recent `-ERR` operation sent by the server.
+	 *
+	 * Updated on every `-ERR`; persists across reconnects (latest wins) so a closed
+	 * connection's failure reason can be correlated with its cause (auth violations,
+	 * permissions violations, slow-consumer kicks, max-payload violations, etc.).
+	 *
+	 * `null` until the first `-ERR` is received.
+	 */
+	var lastError: String? = null,
 ) {
 	internal companion object {
 		val Uninitialised =
@@ -28,6 +38,7 @@ public data class ConnectionState(
 				lastPongAt = null,
 				messagesIn = 0u,
 				messagesOut = 0u,
+				lastError = null,
 			)
 	}
 }

--- a/core/src/commonMain/kotlin/io/natskt/api/NatsClient.kt
+++ b/core/src/commonMain/kotlin/io/natskt/api/NatsClient.kt
@@ -17,6 +17,14 @@ public interface NatsClient {
 	public val connectionState: StateFlow<ConnectionState>
 
 	/**
+	 * The most recent [ServerInfo] published by the server.
+	 *
+	 * Updates on every fresh `INFO` operation, including topology updates pushed by the
+	 * server mid-connection. `null` until the first INFO is received.
+	 */
+	public val serverInfo: StateFlow<ServerInfo?>
+
+	/**
 	 * The subscriptions that have been created with this [NatsClient].
 	 */
 	public val subscriptions: Map<String, Subscription>

--- a/core/src/commonMain/kotlin/io/natskt/client/ClientConfiguration.kt
+++ b/core/src/commonMain/kotlin/io/natskt/client/ClientConfiguration.kt
@@ -18,7 +18,6 @@ internal data class ClientConfiguration(
 	val maxPayloadBytes: Int,
 	val operationBufferCapacity: Int,
 	val writeBufferLimitBytes: Int,
-	val writeFlushIntervalMs: Long,
 	val tlsRequired: Boolean,
 	val maxParallelRequests: Int?,
 	val noResponders: Boolean,

--- a/core/src/commonMain/kotlin/io/natskt/client/ClientConfiguration.kt
+++ b/core/src/commonMain/kotlin/io/natskt/client/ClientConfiguration.kt
@@ -23,6 +23,7 @@ internal data class ClientConfiguration(
 	val maxParallelRequests: Int?,
 	val noResponders: Boolean,
 	val echo: Boolean,
+	val supportUtf8Subjects: Boolean,
 	val nuid: NUID,
 	val scope: CoroutineScope,
 	val ownsScope: Boolean,

--- a/core/src/commonMain/kotlin/io/natskt/client/ClientConfigurationBuilder.kt
+++ b/core/src/commonMain/kotlin/io/natskt/client/ClientConfigurationBuilder.kt
@@ -129,8 +129,11 @@ public class ClientConfigurationBuilder internal constructor() {
 	 * When enabled, the server will send a status 503 response on a request
 	 * when no subscribers are available to handle it, instead of letting the
 	 * request time out.
+	 *
+	 * Defaults to `true` to match the behavior of other NATS clients. Set to
+	 * `false` to disable for legacy compatibility.
 	 */
-	public var noResponders: Boolean = false
+	public var noResponders: Boolean = true
 
 	/**
 	 * When enabled, the server will echo messages published by this client

--- a/core/src/commonMain/kotlin/io/natskt/client/ClientConfigurationBuilder.kt
+++ b/core/src/commonMain/kotlin/io/natskt/client/ClientConfigurationBuilder.kt
@@ -144,6 +144,16 @@ public class ClientConfigurationBuilder internal constructor() {
 	public var echo: Boolean = false
 
 	/**
+	 * Opt in to publishing and subscribing to subjects that contain UTF-8 characters.
+	 *
+	 * Requires a NATS server (>= 2.10) that accepts `utf8_only` in the CONNECT payload.
+	 *
+	 * When enabled, the client tells the server it will use UTF-8 subjects.
+	 * Without this flag, behaviour is unchanged: subjects are treated as ASCII.
+	 */
+	public var supportUtf8Subjects: Boolean = false
+
+	/**
 	 * Tries to connect with TLS first, and forces the server to use TLS.
 	 */
 	public var tlsRequired: Boolean? = null
@@ -210,6 +220,7 @@ internal fun ClientConfigurationBuilder.build(): ClientConfiguration {
 		maxParallelRequests = parallelRequestLimit,
 		noResponders = noResponders,
 		echo = echo,
+		supportUtf8Subjects = supportUtf8Subjects,
 		nuid = NUID.Default,
 		scope = finalScope,
 		ownsScope = scope == null,

--- a/core/src/commonMain/kotlin/io/natskt/client/ClientConfigurationBuilder.kt
+++ b/core/src/commonMain/kotlin/io/natskt/client/ClientConfigurationBuilder.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 public class ClientConfigurationBuilder internal constructor() {
@@ -102,15 +101,6 @@ public class ClientConfigurationBuilder internal constructor() {
 	 * while awaiting a flush to the network.
 	 */
 	public var writeBufferLimitBytes: Int = 64 * 1024
-
-	/**
-	 * Automatically flush the write buffer at this interval, even if it is not full.
-	 *
-	 * This sets the write latency ceiling.
-	 *
-	 * Can be set to [Duration.ZERO] to immediately flush every message in full when it is published.
-	 */
-	public var writeFlushInterval: Duration = 5.milliseconds
 
 	/**
 	 * Set a limit on the maximum number of parallel requests.
@@ -215,7 +205,6 @@ internal fun ClientConfigurationBuilder.build(): ClientConfiguration {
 		maxPayloadBytes = maxPayloadBytes,
 		operationBufferCapacity = operationBufferCapacity,
 		writeBufferLimitBytes = writeBufferLimitBytes,
-		writeFlushIntervalMs = writeFlushInterval.inWholeMilliseconds,
 		tlsRequired = tls,
 		maxParallelRequests = parallelRequestLimit,
 		noResponders = noResponders,

--- a/core/src/commonMain/kotlin/io/natskt/client/NatsClientImpl.kt
+++ b/core/src/commonMain/kotlin/io/natskt/client/NatsClientImpl.kt
@@ -299,7 +299,9 @@ internal class NatsClientImpl(
 			maxMsgs: Int?,
 			->
 			_subscriptions[sid] ?: return@OnSubscriptionStop
-			_subscriptions.remove(sid)
+			if (maxMsgs == null) {
+				_subscriptions.remove(sid)
+			}
 			try {
 				connectionManager.send(ClientOperation.UnSubOp(sid, maxMsgs))
 			} catch (_: ConnectionClosedException) {

--- a/core/src/commonMain/kotlin/io/natskt/client/NatsClientImpl.kt
+++ b/core/src/commonMain/kotlin/io/natskt/client/NatsClientImpl.kt
@@ -10,12 +10,14 @@ import io.natskt.api.ConnectionPhase
 import io.natskt.api.ConnectionState
 import io.natskt.api.Message
 import io.natskt.api.NatsClient
+import io.natskt.api.ServerInfo
 import io.natskt.api.Subject
 import io.natskt.api.Subscription
 import io.natskt.api.from
 import io.natskt.api.internal.InternalNatsApi
 import io.natskt.api.internal.OnSubscriptionStart
 import io.natskt.api.internal.OnSubscriptionStop
+import io.natskt.api.toPublicApi
 import io.natskt.client.connection.ConnectionManagerImpl
 import io.natskt.internal.ClientOperation
 import io.natskt.internal.InternalSubscriptionHandler
@@ -25,9 +27,12 @@ import io.natskt.internal.throwOnInvalidSubject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.ClosedSendChannelException
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.withTimeout
@@ -55,6 +60,11 @@ internal class NatsClientImpl(
 	internal val connectionManager = ConnectionManagerImpl(configuration, _subscriptions, pendingRequests)
 
 	override val connectionState: StateFlow<ConnectionState> = connectionManager.connectionState
+
+	override val serverInfo: StateFlow<ServerInfo?> =
+		connectionManager.serverInfo
+			.map { it?.toPublicApi() }
+			.stateIn(scope, SharingStarted.Eagerly, connectionManager.serverInfo.value?.toPublicApi())
 
 	@OptIn(ExperimentalAtomicApi::class)
 	private val sidAllocator = AtomicLong(1)

--- a/core/src/commonMain/kotlin/io/natskt/client/connection/ConnectionManagerImpl.kt
+++ b/core/src/commonMain/kotlin/io/natskt/client/connection/ConnectionManagerImpl.kt
@@ -76,7 +76,6 @@ internal class ConnectionManagerImpl(
 							supportUtf8Subjects = config.supportUtf8Subjects,
 							operationBufferCapacity = config.operationBufferCapacity,
 							writeBufferLimitBytes = config.writeBufferLimitBytes,
-							writeFlushIntervalMs = config.writeFlushIntervalMs,
 							scope = config.scope,
 						),
 					)

--- a/core/src/commonMain/kotlin/io/natskt/client/connection/ConnectionManagerImpl.kt
+++ b/core/src/commonMain/kotlin/io/natskt/client/connection/ConnectionManagerImpl.kt
@@ -73,6 +73,7 @@ internal class ConnectionManagerImpl(
 							tlsRequired = config.tlsRequired,
 							noResponders = config.noResponders,
 							echo = config.echo,
+							supportUtf8Subjects = config.supportUtf8Subjects,
 							operationBufferCapacity = config.operationBufferCapacity,
 							writeBufferLimitBytes = config.writeBufferLimitBytes,
 							writeFlushIntervalMs = config.writeFlushIntervalMs,

--- a/core/src/commonMain/kotlin/io/natskt/client/connection/ProtocolEngineImpl.kt
+++ b/core/src/commonMain/kotlin/io/natskt/client/connection/ProtocolEngineImpl.kt
@@ -61,7 +61,6 @@ internal class ProtocolEngineImpl(
 	private val supportUtf8Subjects: Boolean,
 	private val operationBufferCapacity: Int,
 	private val writeBufferLimitBytes: Int,
-	private val writeFlushIntervalMs: Long,
 	private val scope: CoroutineScope,
 ) : ProtocolEngine {
 	override val state = MutableStateFlow(ConnectionState.Uninitialised)
@@ -356,49 +355,23 @@ internal class ProtocolEngineImpl(
 			)
 		writerCommands = commands
 		val buffer = TransportWriteBuffer(transport, writeBufferLimitBytes)
-		var lastFlushAt = Clock.System.now().toEpochMilliseconds()
 		writerJob =
 			scope.launch {
 				try {
 					while (isActive) {
-						val commandResult =
-							if (writeFlushIntervalMs > 0) {
-								withTimeoutOrNull(writeFlushIntervalMs) { commands.receiveCatching() }
-							} else {
-								commands.receiveCatching()
-							}
-
-						if (commandResult == null) {
-							buffer.flush()
-							continue
-						}
-
-						val cmd = commandResult.getOrNull()
-						if (cmd == null) {
+						val first = commands.receiveCatching().getOrNull()
+						if (first == null) {
 							buffer.flush()
 							break
 						}
+						handle(first, buffer)
 
-						when (cmd) {
-							is OutboundCommand.Op -> {
-								parser.encode(cmd.op, buffer)
-								val now = Clock.System.now().toEpochMilliseconds()
-								if (writeFlushIntervalMs <= 0 || now - lastFlushAt >= writeFlushIntervalMs || buffer.hasPendingBytesAtCapacity()) {
-									buffer.flush()
-									lastFlushAt = now
-								}
-							}
-
-							is OutboundCommand.Flush -> {
-								runCatching { buffer.flush() }
-									.onSuccess { cmd.ack.complete(Unit) }
-									.onFailure {
-										cmd.ack.completeExceptionally(it)
-										throw it
-									}
-								lastFlushAt = Clock.System.now().toEpochMilliseconds()
-							}
+						while (true) {
+							val next = commands.tryReceive().getOrNull() ?: break
+							handle(next, buffer)
 						}
+
+						buffer.flush()
 					}
 				} catch (_: CancellationException) {
 					commands.close()
@@ -413,6 +386,23 @@ internal class ProtocolEngineImpl(
 					commands.close()
 				}
 			}
+	}
+
+	private suspend inline fun handle(
+		cmd: OutboundCommand,
+		buffer: TransportWriteBuffer,
+	) {
+		when (cmd) {
+			is OutboundCommand.Op -> parser.encode(cmd.op, buffer)
+			is OutboundCommand.Flush -> {
+				runCatching { buffer.flush() }
+					.onSuccess { cmd.ack.complete(Unit) }
+					.onFailure {
+						cmd.ack.completeExceptionally(it)
+						throw it
+					}
+			}
+		}
 	}
 
 	private suspend fun stopWriter() {

--- a/core/src/commonMain/kotlin/io/natskt/client/connection/ProtocolEngineImpl.kt
+++ b/core/src/commonMain/kotlin/io/natskt/client/connection/ProtocolEngineImpl.kt
@@ -247,7 +247,11 @@ internal class ProtocolEngineImpl(
 						}
 
 						is Operation.Err -> {
-							logger.error { "received a protocol error response: ${(out as Operation.Err).message}" }
+							val message = (out as Operation.Err).message
+							logger.error { "received a protocol error response: $message" }
+							if (message != null) {
+								state.update { lastError = message }
+							}
 						}
 
 						Operation.Ok -> {}

--- a/core/src/commonMain/kotlin/io/natskt/client/connection/ProtocolEngineImpl.kt
+++ b/core/src/commonMain/kotlin/io/natskt/client/connection/ProtocolEngineImpl.kt
@@ -58,6 +58,7 @@ internal class ProtocolEngineImpl(
 	private val tlsRequired: Boolean,
 	private val noResponders: Boolean,
 	private val echo: Boolean,
+	private val supportUtf8Subjects: Boolean,
 	private val operationBufferCapacity: Int,
 	private val writeBufferLimitBytes: Int,
 	private val writeFlushIntervalMs: Long,
@@ -96,6 +97,7 @@ internal class ProtocolEngineImpl(
 			noResponders = noResponders,
 			headers = true,
 			nkey = auth.nkey,
+			utf8Only = if (supportUtf8Subjects) true else null,
 		)
 	}
 

--- a/core/src/commonMain/kotlin/io/natskt/client/connection/TransportWriteBuffer.kt
+++ b/core/src/commonMain/kotlin/io/natskt/client/connection/TransportWriteBuffer.kt
@@ -13,8 +13,6 @@ internal class TransportWriteBuffer(
 	private val buffer = ByteArray(capacity.coerceAtLeast(32))
 	private var position = 0
 
-	fun hasPendingBytesAtCapacity(): Boolean = position >= buffer.size
-
 	override suspend fun writeByte(value: Byte) = writeByteFlush(value)
 
 	private suspend inline fun writeByteFlush(value: Byte) {

--- a/core/src/commonMain/kotlin/io/natskt/internal/SubscriptionImpl.kt
+++ b/core/src/commonMain/kotlin/io/natskt/internal/SubscriptionImpl.kt
@@ -57,6 +57,9 @@ internal class SubscriptionImpl(
 	@Volatile
 	private var closed = false
 
+	@Volatile
+	private var remainingDeliveries: Int? = null
+
 	override val messages: Flow<Message> =
 		channelFlow {
 			val activeStateWatcherJob =
@@ -100,7 +103,17 @@ internal class SubscriptionImpl(
 			}
 	}
 
-	override suspend fun emit(msg: Message) = bus.emit(msg)
+	override suspend fun emit(msg: Message) {
+		bus.emit(msg)
+		val current = remainingDeliveries ?: return
+		val next = current - 1
+		if (next <= 0) {
+			remainingDeliveries = 0
+			scope.launch { ensureStopped() }
+		} else {
+			remainingDeliveries = next
+		}
+	}
 
 	private suspend fun ensureStarted() =
 		lifecycle.withLock {
@@ -145,6 +158,14 @@ internal class SubscriptionImpl(
 		closed = true
 		cancelStopIfAny()
 		ensureStopped()
+	}
+
+	override suspend fun unsubscribe(after: Int) {
+		require(after > 0) { "after must be positive" }
+		if (closed) return
+		cancelStopIfAny()
+		remainingDeliveries = after
+		onStop(sid, after)
 	}
 
 	override fun close() {

--- a/core/src/commonTest/kotlin/io/natskt/client/connection/ProtocolEngineHelper.kt
+++ b/core/src/commonTest/kotlin/io/natskt/client/connection/ProtocolEngineHelper.kt
@@ -33,6 +33,7 @@ internal fun engine(
 		tlsRequired = false,
 		noResponders = true,
 		echo = false,
+		supportUtf8Subjects = false,
 		operationBufferCapacity = 32,
 		writeBufferLimitBytes = 64 * 1024,
 		writeFlushIntervalMs = 5,

--- a/core/src/commonTest/kotlin/io/natskt/client/connection/ProtocolEngineHelper.kt
+++ b/core/src/commonTest/kotlin/io/natskt/client/connection/ProtocolEngineHelper.kt
@@ -36,7 +36,6 @@ internal fun engine(
 		supportUtf8Subjects = false,
 		operationBufferCapacity = 32,
 		writeBufferLimitBytes = 64 * 1024,
-		writeFlushIntervalMs = 5,
 		scope =
 			object : CoroutineScope {
 				override val coroutineContext: CoroutineContext = EmptyCoroutineContext

--- a/core/src/commonTest/kotlin/io/natskt/integration/NatsClientIntegrationTest.kt
+++ b/core/src/commonTest/kotlin/io/natskt/integration/NatsClientIntegrationTest.kt
@@ -71,7 +71,11 @@ class NatsClientIntegrationTest {
 	@Test
 	fun `client request engages inbox lifecycle`() =
 		RemoteNatsHarness.runBlocking { server ->
-			val client = NatsClient { this.server = server.uri } as NatsClientImpl
+			val client =
+				NatsClient {
+					this.server = server.uri
+					noResponders = false
+				} as NatsClientImpl
 
 			try {
 				val connectResult = client.connect()

--- a/core/src/commonTest/kotlin/io/natskt/integration/RequestOrderingTest.kt
+++ b/core/src/commonTest/kotlin/io/natskt/integration/RequestOrderingTest.kt
@@ -22,7 +22,11 @@ class RequestOrderingTest {
 	@Test
 	fun `core request sends SUB before PUB`() =
 		RemoteNatsHarness.runBlocking { server ->
-			val client = NatsClient { this.server = server.uri } as NatsClientImpl
+			val client =
+				NatsClient {
+					this.server = server.uri
+					noResponders = false
+				} as NatsClientImpl
 
 			try {
 				val connectResult = client.connect()

--- a/core/src/commonTest/kotlin/io/natskt/internal/SubjectTest.kt
+++ b/core/src/commonTest/kotlin/io/natskt/internal/SubjectTest.kt
@@ -2,13 +2,19 @@
 
 package io.natskt.internal
 
+import io.natskt.api.InvalidSubjectException
 import io.natskt.api.Subject
+import io.natskt.api.SubjectToken
 import io.natskt.api.from
 import io.natskt.api.fromOrNull
+import io.natskt.api.fullyQualified
 import io.natskt.api.internal.InternalNatsApi
+import io.natskt.api.isInvalidFullyQualifiedSubject
 import io.natskt.api.isInvalidSubject
+import io.natskt.api.isInvalidToken
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -24,13 +30,69 @@ class SubjectTest {
 	@Test
 	fun `fromOrNull rejects invalid characters`() {
 		assertEquals(null, Subject.fromOrNull("has space"))
-		assertEquals(null, Subject.fromOrNull("has\u0000null"))
+		assertEquals(null, Subject.fromOrNull("has\tnull"))
 	}
 
 	@Test
-	fun `validateSubject reports invalid tokens`() {
+	fun `subject rejects whitespace and control chars`() {
 		assertTrue(isInvalidSubject("with space"))
-		assertTrue(isInvalidSubject("\u0000binary"))
+		assertTrue(isInvalidSubject("tab\there"))
+		assertTrue(isInvalidSubject("cr\rhere"))
+		assertTrue(isInvalidSubject("lf\nhere"))
 		assertFalse(isInvalidSubject("NATS"))
+	}
+
+	@Test
+	fun `subject rejects empty tokens`() {
+		assertTrue(isInvalidSubject(""))
+		assertTrue(isInvalidSubject("."))
+		assertTrue(isInvalidSubject(".leading"))
+		assertTrue(isInvalidSubject("trailing."))
+		assertTrue(isInvalidSubject("empty..middle"))
+	}
+
+	@Test
+	fun `subject permits utf8 tokens`() {
+		assertFalse(isInvalidSubject("événements.foo"))
+		assertFalse(isInvalidSubject("emoji.😀.suffix"))
+		assertFalse(isInvalidSubject("ключ.значение"))
+	}
+
+	@Test
+	fun `subject permits wildcards`() {
+		assertFalse(isInvalidSubject("orders.*"))
+		assertFalse(isInvalidSubject("orders.>"))
+		assertFalse(isInvalidSubject("orders.*.created"))
+	}
+
+	@Test
+	fun `fullyQualified rejects wildcards`() {
+		assertTrue(isInvalidFullyQualifiedSubject("orders.*"))
+		assertTrue(isInvalidFullyQualifiedSubject("orders.>"))
+		assertFalse(isInvalidFullyQualifiedSubject("orders.created"))
+
+		assertFailsWith<InvalidSubjectException> { Subject.fullyQualified("orders.>") }
+	}
+
+	@Test
+	fun `token rejects whitespace dots wildcards and slashes`() {
+		assertTrue(isInvalidToken(""))
+		assertTrue(isInvalidToken("with space"))
+		assertTrue(isInvalidToken("dot.in.token"))
+		assertTrue(isInvalidToken("star*"))
+		assertTrue(isInvalidToken("gt>"))
+		assertTrue(isInvalidToken("path/with/slash"))
+		assertTrue(isInvalidToken("back\\slash"))
+
+		assertFalse(isInvalidToken("good_token-1"))
+	}
+
+	@Test
+	fun `token permits utf8`() {
+		assertFalse(isInvalidToken("événements"))
+		assertFalse(isInvalidToken("😀"))
+
+		val token = SubjectToken.from("événements")
+		assertEquals("événements", token.token)
 	}
 }

--- a/core/src/commonTest/kotlin/io/natskt/internal/SubscriptionImplTest.kt
+++ b/core/src/commonTest/kotlin/io/natskt/internal/SubscriptionImplTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -108,5 +109,67 @@ class SubscriptionImplTest {
 
 			assertEquals(listOf("2"), stops)
 			assertFalse(subscription.isActive.value)
+		}
+
+	@Test
+	fun `unsubscribe with after issues UNSUB with max_msgs and tears down on count exhaustion`() =
+		runTest {
+			val stops = mutableListOf<Pair<String, Int?>>()
+
+			val subscription =
+				SubscriptionImpl(
+					subject = Subject.from("demo"),
+					queueGroup = null,
+					sid = "auto",
+					scope = this,
+					onStart = { _, _, _, _ -> },
+					onStop =
+						{ sid, maxMsgs ->
+							stops += sid to maxMsgs
+						},
+					eagerSubscribe = true,
+					unsubscribeOnLastCollector = false,
+					prefetchReplay = 0,
+				)
+
+			advanceUntilIdle()
+
+			subscription.unsubscribe(after = 3)
+			advanceUntilIdle()
+
+			assertEquals(listOf<Pair<String, Int?>>("auto" to 3), stops)
+			assertTrue(subscription.isActive.value)
+
+			repeat(3) { subscription.emit(newMessage("payload-$it")) }
+			advanceUntilIdle()
+
+			assertEquals(listOf<Pair<String, Int?>>("auto" to 3, "auto" to null), stops)
+			assertFalse(subscription.isActive.value)
+		}
+
+	@Test
+	fun `unsubscribe with non-positive after rejects`() =
+		runTest {
+			val subscription =
+				SubscriptionImpl(
+					subject = Subject.from("demo"),
+					queueGroup = null,
+					sid = "rej",
+					scope = this,
+					onStart = { _, _, _, _ -> },
+					onStop = { _, _ -> },
+					eagerSubscribe = true,
+					unsubscribeOnLastCollector = false,
+					prefetchReplay = 0,
+				)
+
+			advanceUntilIdle()
+
+			assertFailsWith<IllegalArgumentException> {
+				subscription.unsubscribe(after = 0)
+			}
+
+			subscription.unsubscribe()
+			advanceUntilIdle()
 		}
 }

--- a/core/src/commonTest/kotlin/io/natskt/internal/WriterJobTest.kt
+++ b/core/src/commonTest/kotlin/io/natskt/internal/WriterJobTest.kt
@@ -276,6 +276,7 @@ class WriterJobTest {
 			tlsRequired = false,
 			noResponders = true,
 			echo = false,
+			supportUtf8Subjects = false,
 			operationBufferCapacity = operationBufferCapacity,
 			writeBufferLimitBytes = writeBufferLimitBytes,
 			writeFlushIntervalMs = writeFlushIntervalMs,

--- a/core/src/commonTest/kotlin/io/natskt/internal/WriterJobTest.kt
+++ b/core/src/commonTest/kotlin/io/natskt/internal/WriterJobTest.kt
@@ -19,14 +19,12 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.io.readByteArray
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.Test
-import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -41,7 +39,6 @@ class WriterJobTest {
 					transportFactory = RecordingTransportFactory(transport),
 					scope = this,
 					operationBufferCapacity = 2,
-					writeFlushIntervalMs = 100,
 				)
 
 			engine.start()
@@ -119,7 +116,7 @@ class WriterJobTest {
 		}
 
 	@Test
-	fun `writer flushes on explicit flush call`() =
+	fun `writer flushes after each batch`() =
 		runTest {
 			val transport = RecordingTransport(coroutineContext)
 			val engine =
@@ -127,7 +124,6 @@ class WriterJobTest {
 					serializer = BatchingSerializer(),
 					transportFactory = RecordingTransportFactory(transport),
 					scope = this,
-					writeFlushIntervalMs = Long.MAX_VALUE,
 				)
 
 			engine.start()
@@ -142,118 +138,38 @@ class WriterJobTest {
 			)
 			runCurrent()
 
-			assertEquals(handshakeFlushes, transport.flushCount, "should not auto-flush yet")
+			assertEquals(handshakeFlushes + 1, transport.flushCount, "writer should flush after handling the op")
 
+			engine.close()
+		}
+
+	@Test
+	fun `flush call resolves after pending ops are written`() =
+		runTest {
+			val transport = RecordingTransport(coroutineContext)
+			val engine =
+				engine(
+					serializer = BatchingSerializer(),
+					transportFactory = RecordingTransportFactory(transport),
+					scope = this,
+				)
+
+			engine.start()
+			val handshakeFlushes = transport.flushCount
+
+			engine.send(
+				ClientOperation.PubOp(
+					subject = "test",
+					replyTo = null,
+					payload = "data".encodeToByteArray(),
+				),
+			)
 			engine.flush()
 			runCurrent()
 
-			assertEquals(handshakeFlushes + 1, transport.flushCount, "explicit flush should trigger write")
+			assertTrue(transport.flushCount > handshakeFlushes, "flush should suspend until the op is on the wire")
 
 			engine.close()
-		}
-
-	@Test
-	fun `writer flushes after time interval expires`() =
-		runTest {
-			val transport = RecordingTransport(coroutineContext)
-			val engine =
-				engine(
-					serializer = BatchingSerializer(),
-					transportFactory = RecordingTransportFactory(transport),
-					scope = this,
-					writeFlushIntervalMs = 50,
-				)
-
-			engine.start()
-			val handshakeFlushes = transport.flushCount
-
-			engine.send(
-				ClientOperation.PubOp(
-					subject = "test",
-					replyTo = null,
-					payload = "data".encodeToByteArray(),
-				),
-			)
-
-			advanceTimeBy(60)
-			runCurrent()
-
-			assertTrue(
-				transport.flushCount > handshakeFlushes,
-				"flush should occur after time interval expires",
-			)
-
-			engine.close()
-		}
-
-	@Test
-	fun `writer immediately flushes when interval is zero`() =
-		runTest {
-			val transport = RecordingTransport(coroutineContext)
-			val engine =
-				engine(
-					serializer = BatchingSerializer(),
-					transportFactory = RecordingTransportFactory(transport),
-					scope = this,
-					writeFlushIntervalMs = 0,
-				)
-
-			engine.start()
-			val handshakeFlushes = transport.flushCount
-
-			engine.send(
-				ClientOperation.PubOp(
-					subject = "test",
-					replyTo = null,
-					payload = "data".encodeToByteArray(),
-				),
-			)
-			runCurrent()
-
-			assertEquals(handshakeFlushes + 1, transport.flushCount, "should flush immediately when interval is 0")
-
-			engine.close()
-		}
-
-	@Test
-	fun `writer batches multiple operations in single flush`() =
-		runTest {
-			val transport = RecordingTransport(coroutineContext)
-			val engine =
-				engine(
-					serializer = BatchingSerializer(),
-					transportFactory = RecordingTransportFactory(transport),
-					scope = this,
-					writeFlushIntervalMs = Long.MAX_VALUE,
-				)
-
-			engine.start()
-			val handshakeFlushes = transport.flushCount
-
-			engine.send(
-				ClientOperation.PubOp(
-					subject = "s1",
-					replyTo = null,
-					payload = "a".encodeToByteArray(),
-				),
-			)
-			engine.send(
-				ClientOperation.PubOp(
-					subject = "s2",
-					replyTo = null,
-					payload = "b".encodeToByteArray(),
-				),
-			)
-			runCurrent()
-
-			assertEquals(handshakeFlushes, transport.flushCount, "flush should not run per op")
-
-			engine.close()
-			runCurrent()
-
-			val payloadWrites = transport.writes.lastOrNull() ?: error("expected buffered writes")
-			assertContentEquals("PUB s1 1\r\na\r\nPUB s2 1\r\nb\r\n".encodeToByteArray(), payloadWrites)
-			assertEquals(handshakeFlushes + 1, transport.flushCount, "close should flush pending buffer once")
 		}
 
 	private fun engine(
@@ -261,7 +177,6 @@ class WriterJobTest {
 		transportFactory: TransportFactory,
 		scope: CoroutineScope,
 		writeBufferLimitBytes: Int = 1024,
-		writeFlushIntervalMs: Long = 10_000,
 		operationBufferCapacity: Int = 32,
 	): ProtocolEngineImpl =
 		ProtocolEngineImpl(
@@ -279,7 +194,6 @@ class WriterJobTest {
 			supportUtf8Subjects = false,
 			operationBufferCapacity = operationBufferCapacity,
 			writeBufferLimitBytes = writeBufferLimitBytes,
-			writeFlushIntervalMs = writeFlushIntervalMs,
 			scope = scope,
 		)
 

--- a/core/src/jvmTest/kotlin/io/natskt/client/connection/ConnectionManagerImplTest.kt
+++ b/core/src/jvmTest/kotlin/io/natskt/client/connection/ConnectionManagerImplTest.kt
@@ -74,6 +74,7 @@ class ConnectionManagerImplTest {
 				tlsRequired = false,
 				noResponders = true,
 				echo = false,
+				supportUtf8Subjects = false,
 				nuid = NUID.Default,
 				scope = CoroutineScope(EmptyCoroutineContext),
 				maxParallelRequests = null,

--- a/core/src/jvmTest/kotlin/io/natskt/client/connection/ConnectionManagerImplTest.kt
+++ b/core/src/jvmTest/kotlin/io/natskt/client/connection/ConnectionManagerImplTest.kt
@@ -70,7 +70,6 @@ class ConnectionManagerImplTest {
 				maxControlLineBytes = 1024,
 				operationBufferCapacity = 32,
 				writeBufferLimitBytes = 64 * 1024,
-				writeFlushIntervalMs = 5,
 				tlsRequired = false,
 				noResponders = true,
 				echo = false,

--- a/core/src/jvmTest/kotlin/io/natskt/client/connection/ProtocolEngineImplLameDuckTest.kt
+++ b/core/src/jvmTest/kotlin/io/natskt/client/connection/ProtocolEngineImplLameDuckTest.kt
@@ -69,7 +69,6 @@ class ProtocolEngineImplLameDuckTest {
 			supportUtf8Subjects = false,
 			operationBufferCapacity = 32,
 			writeBufferLimitBytes = 64 * 1024,
-			writeFlushIntervalMs = 5,
 			scope = CoroutineScope(Dispatchers.Unconfined),
 		)
 	}

--- a/core/src/jvmTest/kotlin/io/natskt/client/connection/ProtocolEngineImplLameDuckTest.kt
+++ b/core/src/jvmTest/kotlin/io/natskt/client/connection/ProtocolEngineImplLameDuckTest.kt
@@ -66,6 +66,7 @@ class ProtocolEngineImplLameDuckTest {
 			tlsRequired = false,
 			noResponders = true,
 			echo = false,
+			supportUtf8Subjects = false,
 			operationBufferCapacity = 32,
 			writeBufferLimitBytes = 64 * 1024,
 			writeFlushIntervalMs = 5,

--- a/core/src/jvmTest/kotlin/io/natskt/client/connection/ProtocolEngineImplWriterTest.kt
+++ b/core/src/jvmTest/kotlin/io/natskt/client/connection/ProtocolEngineImplWriterTest.kt
@@ -111,6 +111,7 @@ class ProtocolEngineImplWriterTest {
 			tlsRequired = false,
 			noResponders = true,
 			echo = false,
+			supportUtf8Subjects = false,
 			operationBufferCapacity = 32,
 			writeBufferLimitBytes = writeBufferLimitBytes,
 			writeFlushIntervalMs = 10_000,

--- a/core/src/jvmTest/kotlin/io/natskt/client/connection/ProtocolEngineImplWriterTest.kt
+++ b/core/src/jvmTest/kotlin/io/natskt/client/connection/ProtocolEngineImplWriterTest.kt
@@ -33,7 +33,7 @@ import kotlin.test.fail
 
 class ProtocolEngineImplWriterTest {
 	@Test
-	fun `writer batches ops until flush`() =
+	fun `writer batches drained ops into a single flush`() =
 		runTest {
 			val transport = RecordingTransport(coroutineContext)
 			val engine =
@@ -62,14 +62,11 @@ class ProtocolEngineImplWriterTest {
 			)
 			runCurrent()
 
-			assertEquals(handshakeFlushes, transport.flushCount, "flush should not run per op")
-
-			engine.close()
-			runCurrent()
-
+			assertEquals(handshakeFlushes + 1, transport.flushCount, "drain should produce a single flush")
 			val payloadWrites = transport.writes.lastOrNull() ?: fail("expected buffered writes")
 			assertContentEquals("PUB s1 1\r\na\r\nPUB s2 1\r\nb\r\n".encodeToByteArray(), payloadWrites)
-			assertEquals(handshakeFlushes + 1, transport.flushCount, "close should flush pending buffer once")
+
+			engine.close()
 		}
 
 	@Test
@@ -114,7 +111,6 @@ class ProtocolEngineImplWriterTest {
 			supportUtf8Subjects = false,
 			operationBufferCapacity = 32,
 			writeBufferLimitBytes = writeBufferLimitBytes,
-			writeFlushIntervalMs = 10_000,
 			scope = scope,
 		)
 

--- a/internal/src/commonMain/kotlin/io/natskt/internal/ClientOperation.kt
+++ b/internal/src/commonMain/kotlin/io/natskt/internal/ClientOperation.kt
@@ -32,6 +32,8 @@ sealed interface ClientOperation : Operation {
 		@EncodeDefault
 		val headers: Boolean? = true,
 		val nkey: String?,
+		@SerialName("utf8_only")
+		val utf8Only: Boolean? = null,
 	) : ClientOperation
 
 	@Serializable

--- a/jetstream/src/commonTest/kotlin/io/natskt/jetstream/integration/JetStreamRequestOrderingTest.kt
+++ b/jetstream/src/commonTest/kotlin/io/natskt/jetstream/integration/JetStreamRequestOrderingTest.kt
@@ -23,7 +23,11 @@ class JetStreamRequestOrderingTest {
 	@Test
 	fun `jetstream request sends SUB before PUB`() =
 		RemoteNatsHarness.runBlocking { server ->
-			val client = NatsClient { this.server = server.uri }
+			val client =
+				NatsClient {
+					this.server = server.uri
+					noResponders = false
+				}
 			val js = JetStreamClient(client)
 
 			try {


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                       
   
  Core cleanup batch — a handful of small protocol/API fixes and feature additions                                                                                                                 
  ahead of broader changes:                                       
                                                                                                                                                                                                   
  - **Default `noResponders` to true** so request/no-responder handling matches user expectation out of the box.                                                                                   
  - **Expose `serverInfo` as a `StateFlow`** on `NatsClient` so consumers can react to server identity/capability changes.
  - **Expose the last server `-ERR`** on `ConnectionState` for diagnostics.                                                                                                                        
  - **Support UTF-8 subjects** via opt-in client configuration.                                                                                                                                    
  - **Support `unsubscribe` with max-messages**, matching the wire-level `UNSUB <sid> <max>` form.                                                                                                 
  - **Align `Subject` / `SubjectToken` validation** - fixes a few edge cases where we accepted/rejected subjects inconsistently with the reference implementation.                    
  - **Fix a writer-loop message drop race** in `ProtocolEngineImpl`: the old timer-based flush wrapped `Channel.receive` in `withTimeoutOrNull`, which could silently discard a dequeued           
  `OutboundCommand` on timeout (the channel has no `onUndeliveredElement` handler). Replaced with a drain-and-flush loop; removes the `writeFlushInterval` config (breaking). 